### PR TITLE
Fix npm install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cd <repo-name>
 #### Install Dependencies
 
 ```shell
-npm run install
+npm install
 ```
 
 #### Start the web app


### PR DESCRIPTION
The command how it is like now does not work but throws `npm ERR! Missing script: "install"`. 